### PR TITLE
Improve Gemini fallback and tighten analytics handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@genkit-ai/core": "latest",
         "@genkit-ai/flow": "latest",
         "@google/generative-ai": "^0.24.1",
+        "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "genkit": "^1.16.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "genkit": "^1.16.1",
+    "cors": "^2.8.5",
     "node-fetch": "^3.3.2",
     "undici": "latest",
     "zod": "latest"

--- a/src/ask.ts
+++ b/src/ask.ts
@@ -40,7 +40,7 @@ async function main() {
         property: p.property,
         days: p.days,
         top: p.top,
-        // granularity est toujours "day" côté JQL aujourd'hui
+        granularity: p.granularity,
       } as any);
       console.log("✅ Result:\n", JSON.stringify(res, null, 2));
       return;

--- a/src/mixpanel.ts
+++ b/src/mixpanel.ts
@@ -5,6 +5,12 @@ const PROJECT_ID = process.env.MIXPANEL_PROJECT_ID;
 const SERVICE_ACCOUNT = process.env.MIXPANEL_SERVICE_ACCOUNT;
 const SECRET = process.env.MIXPANEL_SECRET;
 
+if (!PROJECT_ID || !SERVICE_ACCOUNT || !SECRET) {
+  throw new Error(
+    "Missing Mixpanel env (MIXPANEL_PROJECT_ID, MIXPANEL_SERVICE_ACCOUNT, MIXPANEL_SECRET)."
+  );
+}
+
 // Si rien n’est défini, on suppose l’hébergement EU.
 const API_HOST = (process.env.MIXPANEL_API_HOST ?? "").trim() || "https://api-eu.mixpanel.com";
 
@@ -16,14 +22,10 @@ export async function jql<T>(script: string, params: JqlParams = {}): Promise<T>
   bodyParams.set("params", JSON.stringify(params));
   bodyParams.set("project", PROJECT_ID?.toString() ?? "");
 
-  // === DIAGNOSTIC ===
-  console.log("mixpanel.ts] DIAG --- PROJECT_ID:", PROJECT_ID ?? "(undefined)");
-  console.log("mixpanel.ts] DIAG --- API_HOST:", API_HOST);
   const url = `${API_HOST}/api/2.0/jql`;
-  console.log("mixpanel.ts] DIAG --- URL appelée:", url);
 
-  // Pour JQL : Basic Auth avec uniquement l’API Secret en username
-  const auth = Buffer.from(`${SECRET}:`).toString("base64");
+  // Align auth with Mixpanel best practices: service account + secret.
+  const auth = Buffer.from(`${SERVICE_ACCOUNT}:${SECRET}`).toString("base64");
 
   const res = await fetch(url.toString(), {
     method: "POST",

--- a/src/tools/mixpanel.ts
+++ b/src/tools/mixpanel.ts
@@ -1,13 +1,6 @@
 import dotenv from "dotenv";
 dotenv.config();
 
-// 🛠️ Log temporaire (debug uniquement)
-console.log(
-  "Loaded ENV:",
-  process.env.MIXPANEL_PROJECT_ID,
-  process.env.MIXPANEL_SERVICE_ACCOUNT,
-  process.env.MIXPANEL_SECRET ? "SECRET_OK" : "SECRET_MISSING"
-);
 import fetch from "node-fetch";
 
 const MIXPANEL_PROJECT_ID = process.env.MIXPANEL_PROJECT_ID;
@@ -19,7 +12,7 @@ if (!MIXPANEL_PROJECT_ID || !MIXPANEL_SERVICE_ACCOUNT || !MIXPANEL_SECRET) {
 }
 
 async function jql(script: string, params: Record<string, any> = {}) {
-const url = `https://eu.mixpanel.com/api/2.0/jql?project_id=${MIXPANEL_PROJECT_ID}`;
+  const url = `https://eu.mixpanel.com/api/2.0/jql?project_id=${MIXPANEL_PROJECT_ID}`;
   const auth = Buffer.from(
     `${MIXPANEL_SERVICE_ACCOUNT}:${MIXPANEL_SECRET}`
   ).toString("base64");


### PR DESCRIPTION
## Summary
- lazily initialize the Gemini router so the server can fall back to the regex handler when the API key is absent
- extend the CTA timeseries flow and endpoint to validate inputs and aggregate weekly/monthly buckets correctly
- remove Mixpanel credential logging, fix JQL auth, and add the missing cors dependency

## Testing
- npm run test:timeseries *(fails: requires MIXPANEL_* credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68cac4bce2c08332968b748273c77199